### PR TITLE
Initial i18n guide support for fr and hi

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This is a small project right now, so the steps are fairly quick:
 * Check out the [README](README.md) for instructions on getting up and running. It also covers the tech we use and how the site is structure and deployed.
 * (Recommended) use an issue to let folks know you're going to work on something. Either ask if you can be added to an existing issue, or create a new one and add yourself.
 * Fork the repo and make changes in a branch on your fork.
-* As of 2020Q4, we merge directly to head, so create a [pull request](https://github.com/devadvance/terminalcheatsheet/compare) against the default branch.
+* As of 2020Q4, we merge directly to staging, so create a [pull request](https://github.com/devadvance/terminalcheatsheet/compare) against the staging (default) branch.
 
 For any pull request, we prefer these be included:
 
@@ -30,3 +30,5 @@ Visit the [README](README.md) for how to localize and the structure we use.
 ## Don't know where to start?
 
 A good place to start is checking the [existing issues](https://github.com/devadvance/terminalcheatsheet/issues) to check if something interests you. If not, you are welcome add a new issue and (optionally) pick it up!
+
+We are especially interested in supporting new locales, so if Terminal Cheat Sheet isn't translated in your language, please contribute!

--- a/i18n/fr/404.html
+++ b/i18n/fr/404.html
@@ -1,0 +1,15 @@
+---
+layout: default
+title: TODO | Terminal Cheat Sheet
+permalink: /fr/404
+permalink_without_prefix: /404
+lang: fr
+---
+<article class="section-neutral-primary">
+  <h1 class="center">TODO</h1>
+  <br /><br /><br /><br /><br />
+  <div class="centering-div">
+    <a href="/fr/" class="pure-button button-large button-primary">TODO</a>
+  </div>
+  <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+</article>

--- a/i18n/fr/guides/basic-web-server-macos-linux.md
+++ b/i18n/fr/guides/basic-web-server-macos-linux.md
@@ -1,0 +1,15 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /fr/guides/basic-web-server-macos-linux
+permalink_without_prefix: /guides/basic-web-server-macos-linux
+lang: fr
+---
+
+TODO
+
+* TOC
+{:toc}
+
+TODO

--- a/i18n/fr/guides/curl-rest-api.md
+++ b/i18n/fr/guides/curl-rest-api.md
@@ -1,0 +1,15 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /fr/guides/curl-rest-api
+permalink_without_prefix: /guides/curl-rest-api
+lang: fr
+---
+
+TODO
+
+* TOC
+{:toc}
+
+TODO

--- a/i18n/fr/guides/index.md
+++ b/i18n/fr/guides/index.md
@@ -1,0 +1,10 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /fr/guides/
+permalink_without_prefix: /guides/
+lang: fr
+---
+
+{% include i18n/guides/index.md %}

--- a/i18n/fr/guides/navigate-terminal.md
+++ b/i18n/fr/guides/navigate-terminal.md
@@ -1,0 +1,15 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /fr/guides/navigate-terminal
+permalink_without_prefix: /guides/navigate-terminal
+lang: fr
+---
+
+TODO
+
+* TOC
+{:toc}
+
+TODO

--- a/i18n/fr/guides/open-terminal-macos.md
+++ b/i18n/fr/guides/open-terminal-macos.md
@@ -1,0 +1,15 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /fr/guides/open-terminal-macos
+permalink_without_prefix: /guides/open-terminal-macos
+lang: fr
+---
+
+TODO
+
+* TOC
+{:toc}
+
+TODO

--- a/i18n/fr/index.html
+++ b/i18n/fr/index.html
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Terminal Cheat Sheet
+permalink: /fr/
+permalink_without_prefix: /
+lang: fr
+---
+
+TODO

--- a/i18n/hi/404.html
+++ b/i18n/hi/404.html
@@ -1,0 +1,15 @@
+---
+layout: default
+title: TODO | Terminal Cheat Sheet
+permalink: /hi/404
+permalink_without_prefix: /404
+lang: hi
+---
+<article class="section-neutral-primary">
+  <h1 class="center">TODO</h1>
+  <br /><br /><br /><br /><br />
+  <div class="centering-div">
+    <a href="/hi/" class="pure-button button-large button-primary">TODO</a>
+  </div>
+  <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+</article>

--- a/i18n/hi/guides/basic-web-server-macos-linux.md
+++ b/i18n/hi/guides/basic-web-server-macos-linux.md
@@ -1,0 +1,15 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /hi/guides/basic-web-server-macos-linux
+permalink_without_prefix: /guides/basic-web-server-macos-linux
+lang: hi
+---
+
+TODO
+
+* TOC
+{:toc}
+
+TODO

--- a/i18n/hi/guides/curl-rest-api.md
+++ b/i18n/hi/guides/curl-rest-api.md
@@ -1,0 +1,15 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /hi/guides/curl-rest-api
+permalink_without_prefix: /guides/curl-rest-api
+lang: hi
+---
+
+TODO
+
+* TOC
+{:toc}
+
+TODO

--- a/i18n/hi/guides/index.md
+++ b/i18n/hi/guides/index.md
@@ -1,0 +1,10 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /hi/guides/
+permalink_without_prefix: /guides/
+lang: hi
+---
+
+{% include i18n/guides/index.md %}

--- a/i18n/hi/guides/navigate-terminal.md
+++ b/i18n/hi/guides/navigate-terminal.md
@@ -1,0 +1,15 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /hi/guides/navigate-terminal
+permalink_without_prefix: /guides/navigate-terminal
+lang: hi
+---
+
+TODO
+
+* TOC
+{:toc}
+
+TODO

--- a/i18n/hi/guides/open-terminal-macos.md
+++ b/i18n/hi/guides/open-terminal-macos.md
@@ -1,0 +1,15 @@
+---
+layout: guide-layout
+title: TODO
+excerpt: TODO
+permalink: /hi/guides/open-terminal-macos
+permalink_without_prefix: /guides/open-terminal-macos
+lang: hi
+---
+
+TODO
+
+* TOC
+{:toc}
+
+TODO

--- a/i18n/hi/index.html
+++ b/i18n/hi/index.html
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Terminal Cheat Sheet
+permalink: /hi/
+permalink_without_prefix: /
+lang: hi
+---
+
+TODO


### PR DESCRIPTION
## Description

Adds the initial directories for the `fr` and `hi` locales. These will enable folks to contribute more easily.

## Required checklist:

* [x] My code matches the existing code style of this project.
* **One** of these:
	* [ ] My content is localized for all of the locales that this project currently supports.
	* [x] I described above how I plan to localize this content immediately after merging these changes.
* [x] I have tested my code and it successfully builds for GitHub Pages and validates as AMP.
