### PR TITLE
Add french translation to 404 page

### DIFF
--- a/i18n/fr/404.html
+++ b/i18n/fr/404.html
@@ -1,15 +1,15 @@
 ---
 layout: default
-title: TODO | Terminal Cheat Sheet
+title: Introuvable | Terminal Cheat Sheet
 permalink: /fr/404
 permalink_without_prefix: /404
 lang: fr
 ---
 <article class="section-neutral-primary">
-  <h1 class="center">TODO</h1>
+  <h1 class="center">Aucune commande avec cette sortie n'a pu être trouvée.</h1>
   <br /><br /><br /><br /><br />
   <div class="centering-div">
-    <a href="/fr/" class="pure-button button-large button-primary">TODO</a>
+    <a href="/fr/" class="pure-button button-large button-primary">Retour à la page d'accueil</a>
   </div>
   <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
 </article>


### PR DESCRIPTION
## Description
This updates the French translation of the 404 page in [404.html](https://github.com/devadvance/terminalcheatsheet/blob/staging/i18n/fr/404.html). No apparent issues resulting from the changes were noticed and the amp website validations errors were due to my site run locally over HTTP. Check the image below.
![Imgur: terminal](https://imgur.com/ztM823q.png)

Fixes #80  
## Required checklist:

* [x] My code matches the existing code style of this project.
* **One** of these:
	* [ ] This is a new localization for existing content.
	* [ ] This is new content that is localized for all the locales that this project currently supports.
	* [x] I described above how I plan to localize this content immediately after merging these changes.
	* [ ] Localization is not applicable to this change.
* [x] I have tested my code and it successfully builds for GitHub Pages and validates as AMP.