### PR TITLE
fix navbar dropdowns with long text

### DIFF
--- a/_includes/head-styles.html
+++ b/_includes/head-styles.html
@@ -234,6 +234,16 @@ svg {
   margin: 0;
   padding: 0;
   background-color: #ffffff;
+  visibility: hidden;
+  position: absolute !important;
+  transition: all 0.5s ease;
+  display: none !important;
+  right: 30px;
+}
+amp-accordion>section[expanded]>:last-child {
+  display: block!important;
+  visibility: visible;
+  opacity: 1;
 }
 
 .navbar-dropdown li {
@@ -241,6 +251,7 @@ svg {
   text-transform: uppercase;
   margin: 0 1rem;
   line-height: 2.4rem;
+  white-space:nowrap;
 }
 
 .navbar-dropdown>section>header:after {


### PR DESCRIPTION
## Description
Fixed: navbar dropdowns with long text cause the dropdown header to resize

Fixes #58 Bug: navbar dropdowns with long text cause the dropdown header to resize

## Required checklist:

* [x] My code matches the existing code style of this project.
* **One** of these:
	* [ ] This is a new localization for existing content.
	* [ ] This is new content that is localized for all the locales that this project currently supports.
	* [ ] I described above how I plan to localize this content immediately after merging these changes.
	* [ ] Localization is not applicable to this change.
* [x] I have tested my code and it successfully builds for GitHub Pages and validates as AMP.
