### PR TITLE
Clean up translations, focusing on `pt-BR`

### DIFF
--- a/_data/commands/basic.yml
+++ b/_data/commands/basic.yml
@@ -1,7 +1,7 @@
 - id: ls
   command: ls
   descriptions:
-    pt: Lista todos os arquivos no diretório atual
+    pt-BR: Lista todos os arquivos no diretório atual
     en: List the normal files and folders in the current directory in condensed
       format
     es: Enumera los archivos y carpetas normales en el directorio actual
@@ -19,7 +19,7 @@
 - id: pwd
   command: pwd
   descriptions:
-    pt: Mostra o caminho completo para para o diretório atual.
+    pt-BR: Mostra o caminho completo para para o diretório atual.
     en: Output the full path of the current working directory for this terminal
     es: Emita la ruta del directorio actual para este terminal
     ar: إخراج المسار الكامل لدليل العمل الحالي لهذه المحطة
@@ -36,7 +36,7 @@
 - id: cd
   command: cd
   descriptions:
-    pt: Altera o diretório, quando utilizado sozinho por padrão mudará para o
+    pt-BR: Altera o diretório, quando utilizado sozinho por padrão mudará para o
       diretório inicial
     en: Change your current working directory. When used by itself, it will
       default to changing to your home directory
@@ -57,7 +57,7 @@
 - id: cd_folder
   command: cd [FOLDER]
   descriptions:
-    pt: Altera do diretório atual para a pasta informada
+    pt-BR: Altera do diretório atual para a pasta informada
     en: Change your current working directory to the desired [FOLDER]
     es: Cambia su directorio de trabajo actual al [FOLDER] deseado
     ar: تغيير دليل العمل الحالي الخاص بك إلى المجلد المطلو
@@ -74,7 +74,7 @@
 - id: cd_back
   command: cd ..
   descriptions:
-    pt: Altera o diretório do atual para um nível anterior
+    pt-BR: Altera o diretório do atual para um nível anterior
     en: Change your current working directory to the parent directory
     es: Cambia tu directorio de trabajo actual al directorio principal
     ar: تغيير دليل العمل الحالي الخاص بك إلى الدليل الأصل

--- a/_data/commands/files.yml
+++ b/_data/commands/files.yml
@@ -14,7 +14,7 @@
       చేయడానికి పిల్లి ఉపయోగించబడుతుంది
     id: Perintah ini banyak kegunaannya, namun umumnya untuk pemula,
       cat digunakan untuk memunculkan isi dari [FILE] ke terminal
-    pt: Este comando tem muitos usos, mas comumente para iniciantes,
+    pt-BR: Este comando tem muitos usos, mas comumente para iniciantes,
       cat se usa para enviar o conteúdo de um [ARQUIVO] para o terminal
   html_terminal: >
     <span data-ty="input">cat hello.txt</span>
@@ -35,7 +35,7 @@
       ఇది మీ ప్రస్తుత వర్కింగ్ డైరెక్టరీలో సంభవిస్తుంది
     id: Membuat folder sesuai keinginan [NAMA_FOLDER].
       Perintah ini berjalan di direktori kamu berada.
-    pt: Crie uma nova pasta com o [NOME_DA_PASTA] desejada.
+    pt-BR: Crie uma nova pasta com o [NOME_DA_PASTA] desejada.
       Isso ocorre em seu diretório de trabalho atual
   html_terminal: >
     <span data-ty="input">ls</span>
@@ -53,7 +53,7 @@
     hi: अपनी फ़ाइल की एक प्रति बनाना
     te: ఫైల్ యొక్క కాపీని చేయండి
     id: Membuat salinan dari sebuah file
-    pt: Fazer uma cópia de um arquivo
+    pt-BR: Fazer uma cópia de um arquivo
   html_terminal: >
     <span data-ty="input">ls</span>
     <span data-ty>hello.txt</span>
@@ -74,7 +74,7 @@
       ఫైల్స్ మరియు ఫోల్డర్ల పేరు మార్చవచ్చు
     id: Memindahkan file dan folder.
       Bisa juga untuk mengganti nama file dan folder
-    pt: Mover arquivos e pastas. Também pode renomear arquivos e pastas
+    pt-BR: Mover arquivos e pastas. Também pode renomear arquivos e pastas
   html_terminal: >
     <span data-ty="input">ls</span>
     <span data-ty>hello.txt</span>
@@ -91,7 +91,7 @@
     hi: फाइल हटाना
     te: తొలగించు [FILE]
     id: Menghapus file
-    pt: Excluir [ARQUIVO]
+    pt-BR: Excluir [ARQUIVO]
   html_terminal: >
     <span data-ty="input">ls</span>
     <span data-ty>hello.txt world.txt</span>
@@ -113,7 +113,7 @@
       అంటే ఫోల్డర్ మరియు దానిలోని ప్రతిదీ
     id: Menghapus sebuah [FOLDER] secara rekursif,
       yang artinya menghapus folder beserta isinya
-    pt: Eliminar uma [PASTA] recursivamente,
+    pt-BR: Eliminar uma [PASTA] recursivamente,
       o que significa excluir a pasta e tudo que ela contém
   html_terminal: >
     <span data-ty="input">ls</span>

--- a/_data/guides/guide-index.yml
+++ b/_data/guides/guide-index.yml
@@ -5,7 +5,7 @@
     en: How to open terminal on macOS
     es: Cómo abrir terminal en macOS
     ar: كيفية استدعاء محطة على macOS
-    pt: Como abrir o terminal em macOS
+    pt-BR: Como abrir o terminal em macOS
     hi: macOS पर टर्मिनल कैसे खोलें
     id: Cara membuka terminal di macOS
     te: macOS లో టెర్మినల్‌ను ఎలా తెరవాలో
@@ -13,7 +13,7 @@
     en: /guides/open-terminal-macos
     es: /es/guides/open-terminal-macos
     ar: /ar/guides/open-terminal-macos
-    pt: /pt/guides/open-terminal-macos
+    pt-BR: /pt-BR/guides/open-terminal-macos
     hi: /hi/guides/open-terminal-macos
     id: /id/guides/open-terminal-macos
     te: /te/guides/open-terminal-macos
@@ -23,7 +23,7 @@
     en: How to navigate files and folders on a terminal
     es: Cómo navegar con archivos y carpetas en un terminal
     ar: كيفية التنقل في الملفات والمجلدات على جهاز طرفية
-    pt: Como navegar em arquivos e pastas em um terminal
+    pt-BR: Como navegar em arquivos e pastas em um terminal
     hi: टर्मिनल पर फ़ाइलों और फ़ोल्डरों को कैसे नेविगेट करें
     id: Cara menavigasi file dan folder di terminal
     te: టెర్మినలో ఫైల్‌ లు మరియు ఫోల్డర్‌లను ఎలా నావిగేట్ చేయాలి
@@ -31,7 +31,7 @@
     en: /guides/navigate-terminal
     es: /es/guides/navigate-terminal
     ar: /ar/guides/navigate-terminal
-    pt: /pt/guides/navigate-terminal
+    pt-BR: /pt-BR/guides/navigate-terminal
     hi: /hi/guides/navigate-terminal
     id: /id/guides/navigate-terminal
     te: /te/guides/navigate-terminal
@@ -41,7 +41,7 @@
     en: How to use curl to test a REST API
     es: Cómo usar curl para probar una API REST (servicios web)
     ar: كيفية استخدام curl لاختبار REST API
-    pt: Como usar o curl para testar uma REST API
+    pt-BR: Como usar o curl para testar uma REST API
     hi: REST API का परीक्षण करने के लिए कर्ल का उपयोग कैसे करें
     id: Panduan menggunakan curl untuk menguji REST API
     te: REST API లు మరియు సర్వర్‌లతో ఇంటరాక్ట్ అవ్వడానికి curl ను ఉపయోగించడం
@@ -49,7 +49,7 @@
     en: /guides/curl-rest-api
     es: /es/guides/curl-rest-api
     ar: /ar/guides/curl-rest-api
-    pt: /pt/guides/curl-rest-api
+    pt-BR: /pt-BR/guides/curl-rest-api
     hi: /hi/guides/curl-rest-api
     id: /id/guides/curl-rest-api
     te: /te/guides/curl-rest-api
@@ -59,7 +59,7 @@
     en: How to start a basic web server on macOS or Linux
     es: Cómo iniciar un servidor web básico en macOS o Linux
     ar: كيفية بدء تشغيل خادم ويب أساسي على نظام macOS أو Linux
-    pt: Como iniciar um servidor web básico em MacOS ou Linux
+    pt-BR: Como iniciar um servidor web básico em MacOS ou Linux
     hi: macOS या Linux पर एक बेसिक वेब सर्वर कैसे शुरू करें
     id: Bagaimana cara menjalankan web server dasar pada macOS atau Linux
     te: MacOS మరియు Linux లో ప్రాథమిక వెబ్ సర్వర్‌ను ఎలా ప్రారంభించాలి
@@ -67,7 +67,7 @@
     en: /guides/basic-web-server-macos-linux
     es: /es/guides/basic-web-server-macos-linux
     ar: /ar/guides/basic-web-server-macos-linux
-    pt: /pt/guides/basic-web-server-macos-linux
+    pt-BR: /pt-BR/guides/basic-web-server-macos-linux
     hi: /hi/guides/basic-web-server-macos-linux
     id: /id/guides/basic-web-server-macos-linux
     te: /te/guides/basic-web-server-macos-linux

--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -17,9 +17,9 @@ supported_langs:
   # fr:
   #  name: Français
   #  prefix: /fr
-  pt:
+  pt-BR:
     name: Português
-    prefix: /pt
+    prefix: /pt-BR
   id:
     name: Bahasa Indonesia
     prefix: /id
@@ -40,7 +40,7 @@ site_description:
     के लिए आपको आवश्यक सभी ज्ञान।
   fr: Toutes ce que vous avez besoin de savoir pour
     utiliser des terminaux sur différents systèmes d'exploitation.
-  pt: Todo o conhecimento de que você precisa para começar a trabalhar
+  pt-BR: Todo o conhecimento de que você precisa para começar a trabalhar
     em terminair de vários sistemas operacionais
   id: Semua hal yang kamu butuhkan untuk memulai dan menjalankan
     terminal disemua sistem operasi.
@@ -54,7 +54,7 @@ hero_title:
   ar: ما هذا؟
   hi: यह क्या है?
   fr: Qu'est-ce que c'est ?
-  pt: O que é isso?
+  pt-BR: O que é isso?
   id: Apakah ini?
   te: ఇది ఏమిటి?
   ru: Что это?
@@ -80,7 +80,7 @@ hero_description:
     quelques commandes basique du terminal.
     Dans tous les cas, vous êtes au bon endroit.
     Visitez le menu pour d'autres langues.
-  pt: Você pode ser um aspirante a desenvolvedor de software.
+  pt-BR: Você pode ser um aspirante a desenvolvedor de software.
     Talvez você queira apenas revisar alguns comandos básicos do terminal.
     Não importa o motivo, você encontrou o lugar certo.
     Visite o menu para outros idiomas.
@@ -102,7 +102,7 @@ basic_section_title:
   ar: أساسيات
   hi: मूल बातें
   fr: Les bases
-  pt: O básico
+  pt-BR: O básico
   id: Dasar-dasar
   te: ప్రాథాన్యాలు
   ru: Основы
@@ -117,7 +117,7 @@ basic_section_description:
     पता लगाने और प्रदर्शन करने में मदद करेंगे।
   fr: Ces commmandes essentielles vous aideront à naviguer,
     explorer, et à réaliser de simples actions dans votre terminal.
-  pt: Esses comandos essenciais irão ajuá-lo a navegar,
+  pt-BR: Esses comandos essenciais irão ajuá-lo a navegar,
     explore e execute ações simples em seu terminal.
   id: Berikut perintah-perintah penting yang akan membantumu bernavigasi,
     menjelajah, and melakukan tindakan sederhana di terminal kamu.
@@ -131,7 +131,7 @@ files_section_title:
   ar: تعديل الملفات والمجلدات
   hi: फ़ाइलों और फ़ोल्डरों को संशोधित करें
   fr: Modifier des fichiers et dossiers
-  pt: Modificar arquivos e pastas
+  pt-BR: Modificar arquivos e pastas
   id: Memodifikasi file dan folder
   te: ఫైల్‌లు మరియు ఫోల్డర్‌లను సవరించండి
   ru: Изменить файлы и папки
@@ -146,7 +146,7 @@ files_section_description:
     संशोधित करने और हटाने में मदद करेंगे।
   fr: Ces commandes vous aideront à créer,
     modifier, et supprimer des fichiers ainsi que des dossiers.
-  pt: Esses comandos o ajudarão a criar,
+  pt-BR: Esses comandos o ajudarão a criar,
     modificar e excluir arquivos e pastas.
   id: Perintah ini akan membantumu membuat,
     memodifikasi, dan menghapus file dan folder.
@@ -160,7 +160,7 @@ more_coming_soon:
   ar: المزيد قادم قريبا!
   hi: अधिक जल्द ही आ रहा!
   fr: Plus à venir !
-  pt: Mais em breve!
+  pt-BR: Mais em breve!
   id: Selebihnya datang segera!
   te: త్వరలో మరిన్ని రాబోతున్నాయి!
   ru: Продолжение следует!
@@ -171,7 +171,7 @@ begin_reading:
   ar: أبدا
   hi: शुरू हो जाओ
   fr: Commencer
-  pt: Início
+  pt-BR: Início
   id: Memulai
   te: ప్రారంభించడానికి
   ru: Начать
@@ -181,7 +181,7 @@ show_me_action:
   ar: أرني
   hi: मुझे दिखाओ
   fr: Montrer
-  pt: Mostrar
+  pt-BR: Mostrar
   id: Tunjukkan
   te: చూపించు
   ru: Показать
@@ -191,7 +191,7 @@ hide_action:
   ar: إخفاء
   hi: छिपाना
   fr: Cacher
-  pt: Ocultar
+  pt-BR: Ocultar
   id: Sembunyikan
   te: దాచు
   ru: Скрыть
@@ -203,7 +203,7 @@ contact:
   ar: اتصل
   hi: संपर्क करें
   fr: Contact
-  pt: Contato
+  pt-BR: Contato
   id: Kontak
   te: సంప్రదించండి
   ru: Контакты
@@ -213,7 +213,7 @@ more_resources:
   ar: المزيد من الموارد
   hi: और अधिक संसाधनों
   fr: Plus de ressources
-  pt: Mais recursos
+  pt-BR: Mais recursos
   id: Sumber lebih
   te: మరిన్ని వనరులు
   ru: Больше ресурсов
@@ -223,7 +223,7 @@ guides:
   ar: دليل
   hi: गाइड
   fr: Guides
-  pt: Guias
+  pt-BR: Guias
   id: Panduan
   te: గైడ్లు
   ru: Гайды
@@ -233,7 +233,7 @@ language:
   ar: لغة
   hi: भाषा
   fr: Langue
-  pt: Idioma
+  pt-BR: Idioma
   id: Bahasa
   te: భాష
   ru: Язык
@@ -243,7 +243,7 @@ feedback:
   ar: اقتراحات
   hi: प्रतिपुष्टि
   fr: Commentaires
-  pt: Comentários
+  pt-BR: Comentários
   id: Umpan balik
   te: అభిప్రాయం
   ru: Фидбек
@@ -254,7 +254,7 @@ guides_available_title:
   ar: الأدلة المتاحة
   hi: उपलब्ध गाइड
   fr: Guides disponibles
-  pt: Guias disponíveis
+  pt-BR: Guias disponíveis
   id: Panduan tersedia
   te: అందుబాటులో ఉన్న గైడ్‌లు
   ru: Доступные гайды
@@ -264,7 +264,7 @@ guides_available_desc:
   ar: فيما يلي كافة الأدلة المتوفرة حاليًا.
   hi: यहां उन सभी गाइडों के बारे में बताया गया है जो वर्तमान में उपलब्ध हैं।
   fr: Voici tous les guides actuellement disponibles.
-  pt: Aqui estão todas as guias disponíveis atualmente.
+  pt-BR: Aqui estão todas as guias disponíveis atualmente.
   id: Berikut panduan yang sekarang tersedia.
   te: ప్రస్తుతం అందుబాటులో ఉన్న అన్ని గైడ్‌లు ఇక్కడ ఉన్నాయి.
   ru: Все гайды, доступные в настоящее время.

--- a/i18n/pt-BR/404.html
+++ b/i18n/pt-BR/404.html
@@ -1,16 +1,16 @@
 ---
 layout: default
 title: Não encontrado | Terminal Cheat Sheet
-permalink: /pt/404
+permalink: /pt-BR/404
 permalink_without_prefix: /404
-lang: pt
+lang: pt-BR
 ---
 
 <article class="section-neutral-primary">
   <h1 class="center">Nenhum comando com essa saída foi encontrado.</h1>
   <br /><br /><br /><br /><br />
   <div class="centering-div">
-    <a href="/pt/" class="pure-button button-large button-primary">Voltar à página inicial</a>
+    <a href="/pt-BR/" class="pure-button button-large button-primary">Voltar à página inicial</a>
   </div>
   <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
 </article>

--- a/i18n/pt-BR/guides/basic-web-server-macos-linux.md
+++ b/i18n/pt-BR/guides/basic-web-server-macos-linux.md
@@ -14,16 +14,16 @@ lang: pt-BR
 
 ## Introdução
 
-Se você está trabalhando em páginas web ou outros tipos de conteúdo para web, você pode precisar de uma maneira fácil e rápida de iniciar um servidor básico. Esse guia vai te ensinar um comando Python para iniciar um servidor web básico no seu computador. Conforme você seguir as instruções, lembre-se que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem bastante experiência com o terminal, confira [os comandos na página inicial para material de referência rápida](/pt-BR/).
+Se você está trabalhando em páginas web ou outros tipos de conteúdo para web, você pode precisar de uma maneira fácil e rápida de iniciar um servidor básico. Esse guia vai te ensinar um comando Python para iniciar um servidor web básico no seu computador. Conforme você seguir as instruções, lembre-se que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com o terminal, vá para [os comandos na página inicial para o material de referência rápida](/pt-BR/).
 
 ## Pré-requisitos
 
 Para seguir esse guia, você precisará:
 
-- Acesso a um terminal Unix em qualquer ambiente macOS ou Linux.
-- Saber como abrir uma janela do terminal. Se você não sabe ao certo, visite as instruções para [macOS](open-terminal-macos) ou Linux (em breve).
-- Saber como navegar entre arquivos e pastas em um terminal. Se você não sabe ao certo, siga [esse guia antes para aprender](navigate-terminal).
-- Python3 instalado no seu computador. Isso vem instalado por padrão nas versões recentes do macOS e em várias distribuições do Linux.
+* Acesso a um terminal Unix em qualquer ambiente macOS ou Linux.
+* Saber como abrir uma janela do terminal. Se você não sabe ao certo, visite as instruções para [macOS](open-terminal-macos) ou Linux (em breve).
+* Saber como navegar entre arquivos e pastas em um terminal. Se você não sabe ao certo, siga [esse guia antes para aprender](navigate-terminal).
+* Python3 instalado no seu computador. Isso vem instalado por padrão nas versões recentes do macOS e em várias distribuições do Linux.
 
 ## Comece encontrando a pasta certa
 

--- a/i18n/pt-BR/guides/basic-web-server-macos-linux.md
+++ b/i18n/pt-BR/guides/basic-web-server-macos-linux.md
@@ -2,9 +2,9 @@
 layout: guide-layout
 title: Como iniciar um servidor web básico no macOS ou Linux
 excerpt: Esse guia ensina como usar Python para iniciar um servidor web básico a partir de qualquer pastas no seu computador macOS ou Linux.
-permalink: /pt/guides/basic-web-server-macos-linux
+permalink: /pt-BR/guides/basic-web-server-macos-linux
 permalink_without_prefix: /guides/basic-web-server-macos-linux
-lang: pt
+lang: pt-BR
 ---
 
 **Índice**
@@ -14,7 +14,7 @@ lang: pt
 
 ## Introdução
 
-Se você está trabalhando em páginas web ou outros tipos de conteúdo para web, você pode precisar de uma maneira fácil e rápida de iniciar um servidor básico. Esse guia vai te ensinar um comando Python para iniciar um servidor web básico no seu computador. Conforme você seguir as instruções, lembre-se que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem bastante experiência com o terminal, confira [os comandos na página inicial para material de referência rápida](/).
+Se você está trabalhando em páginas web ou outros tipos de conteúdo para web, você pode precisar de uma maneira fácil e rápida de iniciar um servidor básico. Esse guia vai te ensinar um comando Python para iniciar um servidor web básico no seu computador. Conforme você seguir as instruções, lembre-se que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem bastante experiência com o terminal, confira [os comandos na página inicial para material de referência rápida](/pt-BR/).
 
 ## Pré-requisitos
 

--- a/i18n/pt-BR/guides/curl-rest-api.md
+++ b/i18n/pt-BR/guides/curl-rest-api.md
@@ -14,14 +14,14 @@ lang: pt-BR
 
 ## Introdução
 
-Este guia tem como objetivo ensinar os fundamentos da interação com uma API REST usando [curl](https://github.com/curl/curl). Ao seguir essas instruções, lembre-se de que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com terminal no macOS, verifique [os comandos na página inicial para material de referência rápida](/pt-BR/).
+Este guia tem como objetivo ensinar os fundamentos da interação com uma API REST usando [curl](https://github.com/curl/curl). Ao seguir essas instruções, lembre-se de que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com o terminal, vá para [os comandos na página inicial para o material de referência rápida](/pt-BR/).
 
 ## Pré-requisitos
 
 Para seguir este guia, você vai precisar de:
 
-* Acesso a um terminal Unix em qualquer ambiente Linux ou macOS.
-* Saber como abrir uma janela de terminal. Se você não tiver certeza, visite as instruções para [macOS](open-terminal-macos) ou Linux (em breve).
+* Acesso a um terminal Unix em qualquer ambiente macOS ou Linux.
+* Saber como abrir uma janela do terminal. Se você não sabe ao certo, visite as instruções para [macOS](open-terminal-macos) ou Linux (em breve).
 * Uma API REST com a qual você deseja interagir. Estamos usando `https://jsonplaceholder.typicode.com`, como exemplo, neste guia.
 * O comando curl instalado em seu computador. A maioria dos computadores macOS e Linux o tem pré-instalado. Caso contrário, você precisará revisar as instruções técnicas [no site de instalação do curl](https://curl.haxx.se/docs/install.html){:target="_blank" rel="noopener"}.
 

--- a/i18n/pt-BR/guides/curl-rest-api.md
+++ b/i18n/pt-BR/guides/curl-rest-api.md
@@ -2,9 +2,9 @@
 layout: guide-layout
 title: Como usar o curl para testar uma REST API
 excerpt: Como usar o curl para testar uma REST API
-permalink: /pt/guides/curl-rest-api
+permalink: /pt-BR/guides/curl-rest-api
 permalink_without_prefix: /guides/curl-rest-api
-lang: pt
+lang: pt-BR
 ---
 
 **Índice**
@@ -14,7 +14,7 @@ lang: pt
 
 ## Introdução
 
-Este guia tem como objetivo ensinar os fundamentos da interação com uma API REST usando [curl](https://github.com/curl/curl). Ao seguir essas instruções, lembre-se de que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com terminal no macOS, verifique [os comandos na página inicial para material de referência rápida](/).
+Este guia tem como objetivo ensinar os fundamentos da interação com uma API REST usando [curl](https://github.com/curl/curl). Ao seguir essas instruções, lembre-se de que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com terminal no macOS, verifique [os comandos na página inicial para material de referência rápida](/pt-BR/).
 
 ## Pré-requisitos
 

--- a/i18n/pt-BR/guides/index.md
+++ b/i18n/pt-BR/guides/index.md
@@ -2,9 +2,9 @@
 layout: guide-layout
 title: TODO
 excerpt: TODO
-permalink: /pt/guides/
+permalink: /pt-BR/guides/
 permalink_without_prefix: /guides/
-lang: pt
+lang: pt-BR
 ---
 
 {% include i18n/guides/index.md %}

--- a/i18n/pt-BR/guides/index.md
+++ b/i18n/pt-BR/guides/index.md
@@ -1,7 +1,7 @@
 ---
 layout: guide-layout
-title: TODO
-excerpt: TODO
+title: Guias disponíveis
+excerpt: Aqui estão todas as guias disponíveis atualmente
 permalink: /pt-BR/guides/
 permalink_without_prefix: /guides/
 lang: pt-BR

--- a/i18n/pt-BR/guides/navigate-terminal.md
+++ b/i18n/pt-BR/guides/navigate-terminal.md
@@ -14,14 +14,14 @@ lang: pt-BR
 
 ## Introdução
 
-Este guia tem como objetivo ensinar os fundamentos básicos da navegação em arquivos e pastas em um terminal. Ao seguir essas instruções, lembre-se de que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com o terminal, verifique [os comandos na página inicial para o material de referência rápida](/pt-BR/).
+Este guia tem como objetivo ensinar os fundamentos básicos da navegação em arquivos e pastas em um terminal. Ao seguir essas instruções, lembre-se de que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com o terminal, vá para [os comandos na página inicial para o material de referência rápida](/pt-BR/).
 
 ## Pré-requisitos
 
 Para seguir este guia, você precisará de:
 
-* Acesso a um terminal Unix em qualquer ambiente Linux ou macOS.
-* Para saber como abrir uma janela de terminal. Se você não tiver certeza, visite as instruções para [macOS] (open-terminal-macos) ou Linux (em breve).
+* Acesso a um terminal Unix em qualquer ambiente macOS ou Linux.
+* Saber como abrir uma janela do terminal. Se você não sabe ao certo, visite as instruções para [macOS](open-terminal-macos) ou Linux (em breve).
 
 ## Vamos começar!
 

--- a/i18n/pt-BR/guides/navigate-terminal.md
+++ b/i18n/pt-BR/guides/navigate-terminal.md
@@ -2,9 +2,9 @@
 layout: guide-layout
 title: Como navegar em arquivos e pastas em um terminal
 excerpt: Este guia tem como objetivo ensinar os fundamentos básicos da navegação em arquivos e pastas em um terminal.
-permalink: /pt/guides/navigate-terminal
+permalink: /pt-BR/guides/navigate-terminal
 permalink_without_prefix: /guides/navigate-terminal
-lang: pt
+lang: pt-BR
 ---
 
 **Índice**
@@ -14,7 +14,7 @@ lang: pt
 
 ## Introdução
 
-Este guia tem como objetivo ensinar os fundamentos básicos da navegação em arquivos e pastas em um terminal. Ao seguir essas instruções, lembre-se de que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com o terminal, verifique [os comandos na página inicial para o material de referência rápida] (/).
+Este guia tem como objetivo ensinar os fundamentos básicos da navegação em arquivos e pastas em um terminal. Ao seguir essas instruções, lembre-se de que os arquivos e pastas do seu computador provavelmente serão diferentes dos exemplos. Se você já tem muita experiência com o terminal, verifique [os comandos na página inicial para o material de referência rápida](/pt-BR/).
 
 ## Pré-requisitos
 

--- a/i18n/pt-BR/guides/open-terminal-macos.md
+++ b/i18n/pt-BR/guides/open-terminal-macos.md
@@ -7,14 +7,14 @@ permalink_without_prefix: /guides/open-terminal-macos
 lang: pt-BR
 ---
 
-Índice
+**Índice**
 
 * TOC
 {:toc}
 
 ## Introdução
 
-Esse guia tem o propósito de ensinar-lhe como encontrar o terminal no macOS e como abrir o terminal no macOS. Se você tem bastante experiência com terminal, vá para [os comandos da página inicial para um materil de referência rápida](/pt-BR/).
+Esse guia tem o propósito de ensinar-lhe como encontrar o terminal no macOS e como abrir o terminal no macOS. Se você já tem muita experiência com o terminal, vá para [os comandos na página inicial para o material de referência rápida](/pt-BR/).
 
 ## Pré-requisitos
 

--- a/i18n/pt-BR/guides/open-terminal-macos.md
+++ b/i18n/pt-BR/guides/open-terminal-macos.md
@@ -2,9 +2,9 @@
 layout: guide-layout
 title: Como abrir o terminal no macOS
 excerpt: Esse guia tem o propósito de ensinar-lhe como encontrar terminal no macOS e como abrir o terminal no macOS.
-permalink: /pt/guides/open-terminal-macos
+permalink: /pt-BR/guides/open-terminal-macos
 permalink_without_prefix: /guides/open-terminal-macos
-lang: pt
+lang: pt-BR
 ---
 
 Índice
@@ -14,7 +14,7 @@ lang: pt
 
 ## Introdução
 
-Esse guia tem o propósito de ensinar-lhe como encontrar o terminal no macOS e como abrir o terminal no macOS. Se você tem bastante experiência com terminal, vá para [os comandos da página inicial para um materil de referência rápida](/).
+Esse guia tem o propósito de ensinar-lhe como encontrar o terminal no macOS e como abrir o terminal no macOS. Se você tem bastante experiência com terminal, vá para [os comandos da página inicial para um materil de referência rápida](/pt-BR/).
 
 ## Pré-requisitos
 
@@ -67,4 +67,4 @@ Seja usando Spotlight ou Finder, uma janela de terminal irá abrir.
   <amp-img src="/assets/guides/open-terminal-macos/terminal-open-en.png" width="585" height="389" alt="An open terminal window" layout="responsive"></amp-img>
 </div>
 
-Agora que você já abriu seu terminal, experimente alguns comandos no [dicas](/#basic)!
+Agora que você já abriu seu terminal, experimente alguns comandos no [dicas](/pt-BR/#basic)!

--- a/i18n/pt-BR/index.html
+++ b/i18n/pt-BR/index.html
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: Terminal Cheat Sheet
-permalink: /pt/
+permalink: /pt-BR/
 permalink_without_prefix: /
-lang: pt
+lang: pt-BR
 ---
 
-TODO
+{% include i18n/index.html %}


### PR DESCRIPTION
## Description

This PR continues to clean up the new translations. It also changes the locale code for Portuguese from `pt` to `pt-BR`, as the translations are Brazilian Portuguese.

## Required checklist:

* [x] My code matches the existing code style of this project.
* **One** of these:
	* [x] This is a new localization for existing content.
	* [ ] This is new content that is localized for all the locales that this project currently supports.
	* [ ] I described above how I plan to localize this content immediately after merging these changes.
	* [ ] Localization is not applicable to this change.
* [x] I have tested my code and it successfully builds for GitHub Pages and validates as AMP.
