### PR TITLE
Switch navbar to JS-less version

### DIFF
--- a/_includes/body-button-copy.html
+++ b/_includes/body-button-copy.html
@@ -4,7 +4,7 @@
     width="84"
     height="36"
     frameborder="0"
-    src="{{site.url}}/copier.html#{{include.content.command}}">
+    src="/copier.html#{{include.content.command}}">
     <button class="pure-button button-large button-primary"
     placeholder
     disabled>Copy</button>

--- a/_includes/body-button-show-hide.html
+++ b/_includes/body-button-show-hide.html
@@ -4,7 +4,7 @@
         <span class="show-more">{{site.data.translations.show_me_action[page.lang]}}</span>
         <span class="show-less">{{site.data.translations.hide_action[page.lang]}}</span>
     </header>
-    <amp-script height="300" layout="fixed-height" src="{{ site.url }}/termynal.js">
+    <amp-script height="300" layout="fixed-height" src="/termynal.js">
         <div class="termynal" data-termynal data-ty-progress-length="10" data-ty-line-delay="800" dir="ltr">
         {{include.content.html_terminal}}
         </div>

--- a/_includes/body-navbar.html
+++ b/_includes/body-navbar.html
@@ -1,91 +1,87 @@
-  <!-- Start navbar -->
-  <nav class="header-navbar">
-    <div class="nav-title">
-      <a href="{{site.data.translations.supported_langs[page.lang].prefix}}/" class="text-decoration-none">Terminal Cheat Sheet</a>
-    </div>
-    <div role="button" aria-label="open sidebar" on="tap:header-sidebar.toggle" tabindex="0" class="sidebar-trigger lg-hide">☰</div>
-    <div class="nav-items md-hide sm-hide xs-hide">
-      <ul class="list-reset horiz-list">
+<nav class="navbar">
+  <details class="navbar-sidebar navbar-details navbar-top-details">
+    <summary id="navbar-main-menu-title" class="navbar-details-title">☰</summary>
+    <div class="navbar-details-content">
+      <ul aria-labelledby="navbar-main-menu-title">
         <li>
-          <amp-accordion layout="container" disable-session-states="" class="navbar-dropdown">
-            <section>
-              <header>{{site.data.translations.language[page.lang]}}</header>
-              <ul class="list-reset">
+          <details class="navbar-details">
+            <summary id="navbar-language-subsection-title" class="navbar-details-title">{{site.data.translations.language[page.lang]}}</summary>
+            <div class="navbar-details-content">
+              <ul aria-labelledby="navbar-language-subsection-title">
                 {% for supported_lang in site.data.translations.supported_langs %}
                 <li><a href="{{supported_lang[1].prefix}}{{page.permalink_without_prefix}}" class="text-decoration-none">{{supported_lang[1].name}}</a></li>
                 {% endfor %}
               </ul>
-            </section>
-          </amp-accordion>
+            </div>
+          </details>
         </li>
         <li>
-          <amp-accordion layout="container" disable-session-states="" class="navbar-dropdown">
-            <section>
-              <header>{{site.data.translations.guides[page.lang]}}</header>
-              <ul class="list-reset">
+          <details class="navbar-details">
+            <summary id="navbar-guides-subsection-title" class="navbar-details-title">{{site.data.translations.guides[page.lang]}}</summary>
+            <div class="navbar-details-content">
+              <ul aria-labelledby="navbar-guides-subsection-title">
                 {% for guide in site.data.guides.guide-index %}
                 <li><a href="{{guide.link[page.lang]}}" class="text-decoration-none">{{guide.title[page.lang]}}</a></li>
                 {% endfor %}
               </ul>
-            </section>
-          </amp-accordion>
+            </div>
+          </details>
         </li>
         <li>
-          <amp-accordion layout="container" disable-session-states="" class="navbar-dropdown">
-            <section>
-              <header>{{site.data.translations.more_resources[page.lang]}}</header>
-              <ul class="list-reset">
+          <details class="navbar-details">
+            <summary id="navbar-resources-subsection-title" class="navbar-details-title">{{site.data.translations.more_resources[page.lang]}}</summary>
+            <div class="navbar-details-content">
+              <ul aria-labelledby="navbar-resources-subsection-title">
                 <li><a href="https://linux.die.net/man/" class="text-decoration-none" target="_blank" rel="noopener">Linux man pages</a></li>
                 <li><a href="mailto:hello@terminalcheatsheet.com" class="text-decoration-none" target="_blank" rel="noopener">{{site.data.translations.contact[page.lang]}}</a></li>
                 <li><a href="https://rebrand.ly/TCSFeedback" class="text-decoration-none" target="_blank" rel="noopener">{{site.data.translations.feedback[page.lang]}}</a></li>
               </ul>
-            </section>
-          </amp-accordion>
+            </div>
+          </details>
         </li>
+        {% include body-shareicons.html %}
       </ul>
     </div>
-  </nav>
-
-  <!-- Start sidebar -->
-  <amp-sidebar id="header-sidebar" class="custom-sidebar" layout="nodisplay" side="left">
-    <div role="button" aria-label="close sidebar" on="tap:header-sidebar.toggle" tabindex="0" class="sidebar-trigger sidebar-close-button">✕</div>
-    <ul class="list-reset">
+  </details>
+  <div class="navbar-title"><a href="/" class="text-decoration-none">Terminal Cheat Sheet</a></div>
+  <div class="navbar-horiz">
+    <ul class="navbar-horiz-list">
       <li>
-        <amp-accordion layout="container" disable-session-states="" class="sidebar-dropdown">
-          <section>
-            <header>{{site.data.translations.language[page.lang]}}</header>
-            <ul class="list-reset">
-              {% for supported_lang in site.data.translations.supported_langs %}
-              <li><a href="{{supported_lang[1].prefix}}{{page.permalink_without_prefix}}" class="text-decoration-none">{{supported_lang[1].name}}</a></li>
-              {% endfor %}
+        <details class="navbar-details navbar-top-details">
+          <summary id="navbar-languages-title" class="navbar-details-title">{{site.data.translations.language[page.lang]}}</summary>
+          <div class="navbar-details-content">
+            <ul aria-labelledby="navbar-languages-title">
+                {% for supported_lang in site.data.translations.supported_langs %}
+                <li><a href="{{supported_lang[1].prefix}}{{page.permalink_without_prefix}}" class="text-decoration-none">{{supported_lang[1].name}}</a></li>
+                {% endfor %}
             </ul>
-          </section>
-        </amp-accordion>
+          </div>
+        </details>
       </li>
       <li>
-        <amp-accordion layout="container" disable-session-states="" class="sidebar-dropdown">
-          <section>
-            <header>{{site.data.translations.guides[page.lang]}}</header>
-            <ul class="list-reset">
-              {% for guide in site.data.guides.guide-index %}
-              <li><a href="{{guide.link[page.lang]}}" class="text-decoration-none">{{guide.title[page.lang]}}</a></li>
-              {% endfor %}
+        <details class="navbar-details navbar-top-details">
+          <summary id="navbar-guides-title" class="navbar-details-title">{{site.data.translations.guides[page.lang]}}</summary>
+          <div class="navbar-details-content">
+            <ul aria-labelledby="navbar-guides-title">
+                {% for guide in site.data.guides.guide-index %}
+                <li><a href="{{guide.link[page.lang]}}" class="text-decoration-none">{{guide.title[page.lang]}}</a></li>
+                {% endfor %}
             </ul>
-          </section>
-        </amp-accordion>
+          </div>
+        </details>
       </li>
       <li>
-        <amp-accordion layout="container" disable-session-states="" class="sidebar-dropdown">
-          <section>
-            <header>{{site.data.translations.more_resources[page.lang]}}</header>
-            <ul class="list-reset">
+        <details class="navbar-details navbar-top-details">
+          <summary id="navbar-resources-title" class="navbar-details-title">{{site.data.translations.more_resources[page.lang]}}</summary>
+          <div class="navbar-details-content">
+            <ul aria-labelledby="navbar-resources-title">
               <li><a href="https://linux.die.net/man/" class="text-decoration-none" target="_blank" rel="noopener">Linux man pages</a></li>
               <li><a href="mailto:hello@terminalcheatsheet.com" class="text-decoration-none" target="_blank" rel="noopener">{{site.data.translations.contact[page.lang]}}</a></li>
               <li><a href="https://rebrand.ly/TCSFeedback" class="text-decoration-none" target="_blank" rel="noopener">{{site.data.translations.feedback[page.lang]}}</a></li>
             </ul>
-          </section>
-        </amp-accordion>
+          </div>
+        </details>
       </li>
-      {% include body-shareicons.html %}
     </ul>
-  </amp-sidebar>
+  </div>
+</nav>

--- a/_includes/head-styles.html
+++ b/_includes/head-styles.html
@@ -176,148 +176,9 @@ svg {
   padding-left: 0;
 }
 
-/* Styles for the navbar and sidebar.
-   These are somewhat specific to AMP, such
-   as the accordion and dropdown
- */
-.header-navbar {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: 3.75rem;
-  line-height: 3.75rem;
-  z-index: 999;
-  background-color: var(--color-primary);
-  color: var(--color-text-primary);
-  box-shadow: 0 0 0.3125rem 0.125rem rgba(0,0,0,.1);
-}
-
-.header-navbar .nav-title {
-  float: left;
-  margin-left: 3.5rem;
-  font-weight: bold;
-  font-size: 1.25rem;
-}
-
-.nav-items a, .nav-title a {
-  display: block;
-}
-
-.header-navbar .nav-items {
-  float: right;
-  color: var(--color-text-primary);
-  font-weight: bold;
-}
-
-.nav-items>ul {
-  margin: 0 3.125rem 0 0;
-  display: flex;
-}
-
-.nav-items>ul>li {
-  flex: 0 1 auto;
-  margin: 0 0.9375rem 0 0.9375rem;
-}
-
-.navbar-dropdown {
-  min-width: 9rem;
-}
-
-.navbar-dropdown>section>header {
-  background-color: var(--color-primary);
-  border: 0;
-  margin: 0 1rem;
-}
-
-.navbar-dropdown>section>ul {
-  margin: 0;
-  padding: 0;
-  background-color: #ffffff;
-  visibility: hidden;
-  position: absolute;
-  transition: all 0.5s ease;
-  display: none;
-  right: 1.875rem;
-}
-
-amp-accordion>section[expanded]>:last-child {
-  display: block;
-  visibility: visible;
-  opacity: 1;
-}
-
-.navbar-dropdown li {
-  color: var(--color-text-primary);
-  text-transform: uppercase;
-  margin: 0 1rem;
-  line-height: 2.4rem;
-  white-space: nowrap;
-}
-
-.navbar-dropdown>section>header:after {
-  display: inline-block;
-  content: "+";
-  padding: 0 0 0 1.5rem;
-  color: var(--color-text-primary);
-}
-
-.navbar-dropdown>[expanded]>header:after {
-  content: "–";
-}
-
-.sidebar-trigger {
-  position: absolute;
-  left: 0;
-  top: 0;
-  margin-left: 0.625rem;
-  font-weight: bold;
-  font-size: 1.5rem;
-  cursor: pointer;
-  padding: 0 0.5rem 0 0.5rem;
-}
-
-.sidebar-close-button {
-  margin-top: 0.625rem;
-}
-
 .text-decoration-none {
   text-decoration: none;
   color: inherit;
-}
-
-.custom-sidebar {
-  background-color: var(--color-neutral-light);
-  color: var(--color-text-primary);
-  min-width: 18.75rem;
-  width: 18.75rem;
-  padding-left: 0.625rem;
-  padding-top: 2.5rem;
-}
-
-.custom-sidebar li {
-  margin-bottom: 1.5rem;
-}
-
-.sidebar-dropdown>section>header {
-  background-color: transparent;
-  margin-bottom: 1.25rem;
-  border: 0;
-}
-
-.sidebar-dropdown>section>ul {
-  padding-left: 1.25rem;
-}
-
-.sidebar-dropdown>section>header:after {
-  display: inline-block;
-  content: "+";
-  padding: 0 0 0 1.5rem;
-  color: #000000;
-}
-
-.sidebar-dropdown>[expanded]>header:after {
-  content: "–";
 }
 
 /* using the :not() selector to avoid conflicting with PureCSS buttons */
@@ -687,6 +548,135 @@ imgcaption {
 #markdown-toc {
   line-height: 2rem;
   font-size: 1.1rem;
+}
+
+
+
+/* The top navbar itself. */
+.navbar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 3.75rem;
+  line-height: 3.75rem;
+  font-weight: bold;
+  font-size: 1rem;
+  z-index: 999;
+  background-color: var(--color-primary);
+  color: var(--color-text-primary);
+  box-shadow: 0 0 5px 2px rgba(0,0,0,.1);
+  text-align: center;
+}
+
+.navbar-title {
+  /*margin: 0 0 0 3rem;*/
+  margin: 0 auto 0 auto;
+  font-size: 1.25rem;
+}
+
+.navbar a {
+  text-decoration: none;
+  color: #000000;
+  padding: 0.75rem;
+}
+
+/* Any direct children of the navbar should be horizontal and aligned to top. */
+.navbar > * {
+  display: inline-block;
+  vertical-align: top;
+}
+
+.navbar > .navbar-horiz {
+  display: none;
+}
+
+/* Specific to the sidebar menu details. */
+.navbar-sidebar {
+  width: 6rem;
+  position: absolute;
+  left: 0;
+  text-align: left;
+}
+
+.navbar-details {
+  cursor: pointer;
+}
+
+details.navbar-details > summary {
+  display: list-item;
+  padding-left: 1.5rem;
+}
+
+/* The content of the details dropdown. */
+.navbar-details-content {
+  background-color: #ffffff;
+  line-height: 1.8rem;
+  font-size: 1.2rem;
+  overflow: visible;
+}
+
+/*
+ * Position absolute so that it doesn't change
+ * the size of the header.
+ */
+.navbar-top-details > .navbar-details-content {
+  position: absolute;
+  width: 13rem;
+  background-color: #ffffff;
+}
+
+/* When used as a sidebar, we have the height as the entire screen and a wider bar. */
+.navbar-sidebar > .navbar-details-content {
+  height: 100vh;
+  width: 15rem;
+}
+
+/* Lists in the dropdowns have no style. */
+.navbar-details-content > ul {
+  list-style: none;
+  padding-left: 1rem;
+}
+
+.navbar-details-content > ul > li {
+  padding: 0.5rem 0.125rem 0.5rem 0;
+}
+
+/* For the horizontal list. */
+.navbar-horiz, .navbar-horiz-list {
+  display: inline-block;
+  list-style: none;
+  vertical-align: top;
+  margin: 0 1rem 0 0;
+  float: right;
+}
+
+/* For the horizontal list. */
+.navbar-horiz-list > li {
+  display: inline-block;
+  margin: 0 0.25rem 0 0.25rem;
+  height: 100%;
+}
+
+/* For larger screens we:
+ * * turn off the sidebar
+ * * turn on horizontal nav
+*/
+@media (min-width: 768px) {
+  .navbar {
+    text-align: left;
+  }
+
+  .navbar-sidebar {
+    display: none;
+  }
+  
+  .navbar > .navbar-horiz {
+    display: inline-block;
+  }
+  .navbar-title {
+    margin: 0 0 0 2rem;
+  }
 }
 
 </style>


### PR DESCRIPTION
## Description

Changes the site navigation implementation to no longer require JavaScript. This ensures that the site is usable even by folks who have JS (or AMP specifically) disabled.

For details on this implementation, please visit https://mattj.io/posts/2021-06-07-site-navigation-html-css-only/.
